### PR TITLE
open slack contact in new tab

### DIFF
--- a/src/js/table.js
+++ b/src/js/table.js
@@ -191,6 +191,8 @@ class Entry extends React.Component {
           <ReactGA.OutboundLink
             eventLabel="Contact"
             to={contact_url}
+            target="_blank"
+            rel="noopener noreferrer"
           >
             contact
           </ReactGA.OutboundLink>


### PR DESCRIPTION
opening slack in a new tab rather than cannibalizing the current tab makes for a smoother user flow. 